### PR TITLE
Add PropsRoute component, authenticate and save profile to localStorage, add logout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 # luber
 
-##Install dependencies
+## Install dependencies
 ```
 yarn install
 ```
 
-##Start me up
+## Start me up
 This uses react-scripts. It will run on http://localhost:3000
 ```
 npm start
 ```
 
 
-##Alternatively, use "docker-compose"
+## Alternatively, use "docker-compose"
 If you have docker installed, you can just run the following command:
 ```
 docker-compose up -d

--- a/package-lock.json
+++ b/package-lock.json
@@ -9201,12 +9201,29 @@
       }
     },
     "prop-types": {
-      "version": "15.5.10",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.5.10.tgz",
-      "integrity": "sha1-J5ffwxJhguOpXj37suiT3ddFYVQ=",
+      "version": "15.6.0",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.0.tgz",
+      "integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
       "requires": {
-        "fbjs": "0.8.12",
-        "loose-envify": "1.3.1"
+        "fbjs": "0.8.16",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1"
+      },
+      "dependencies": {
+        "fbjs": {
+          "version": "0.8.16",
+          "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
+          "integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
+          "requires": {
+            "core-js": "1.2.7",
+            "isomorphic-fetch": "2.2.1",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1",
+            "promise": "7.3.1",
+            "setimmediate": "1.0.5",
+            "ua-parser-js": "0.7.14"
+          }
+        }
       }
     },
     "proxy-addr": {
@@ -9403,7 +9420,7 @@
         "fbjs": "0.8.12",
         "loose-envify": "1.3.1",
         "object-assign": "4.1.1",
-        "prop-types": "15.5.10"
+        "prop-types": "15.6.0"
       }
     },
     "react-dev-utils": {
@@ -9595,7 +9612,7 @@
         "fbjs": "0.8.12",
         "loose-envify": "1.3.1",
         "object-assign": "4.1.1",
-        "prop-types": "15.5.10"
+        "prop-types": "15.6.0"
       }
     },
     "react-error-overlay": {
@@ -9641,7 +9658,7 @@
         "lodash": "4.17.4",
         "lodash-es": "4.17.4",
         "loose-envify": "1.3.1",
-        "prop-types": "15.5.10"
+        "prop-types": "15.6.0"
       },
       "dependencies": {
         "hoist-non-react-statics": {
@@ -9656,7 +9673,7 @@
       "resolved": "https://registry.npmjs.org/react-resize-detector/-/react-resize-detector-0.6.0.tgz",
       "integrity": "sha512-YByNIF+8VZo1R3tCklf27JsYRCFWWLYP1OyY1CQZKzBDufcY06FBp4OvvcoUiaG0+X+kHpzYJQ3is7KrLR0d0A==",
       "requires": {
-        "prop-types": "15.5.10"
+        "prop-types": "15.6.0"
       }
     },
     "react-router": {
@@ -9669,7 +9686,7 @@
         "invariant": "2.2.2",
         "loose-envify": "1.3.1",
         "path-to-regexp": "1.7.0",
-        "prop-types": "15.5.10",
+        "prop-types": "15.6.0",
         "warning": "3.0.0"
       },
       "dependencies": {
@@ -9710,7 +9727,7 @@
         "history": "4.7.2",
         "invariant": "2.2.2",
         "loose-envify": "1.3.1",
-        "prop-types": "15.5.10",
+        "prop-types": "15.6.0",
         "react-router": "4.2.0",
         "warning": "3.0.0"
       },
@@ -9745,7 +9762,7 @@
       "integrity": "sha1-dBhmPC7NPFG+hW/PKPPR3uzBpXY=",
       "requires": {
         "history": "4.6.3",
-        "prop-types": "15.5.10",
+        "prop-types": "15.6.0",
         "react-router": "4.1.2"
       },
       "dependencies": {
@@ -9759,7 +9776,7 @@
             "invariant": "2.2.2",
             "loose-envify": "1.3.1",
             "path-to-regexp": "1.7.0",
-            "prop-types": "15.5.10",
+            "prop-types": "15.6.0",
             "warning": "3.0.0"
           }
         }
@@ -9827,7 +9844,7 @@
       "integrity": "sha1-tnZl17mCAlfjQnnBXgLo5RMevpk=",
       "requires": {
         "lodash": "4.17.4",
-        "prop-types": "15.5.10",
+        "prop-types": "15.6.0",
         "raf": "3.4.0",
         "react-transition-group": "1.2.1"
       }
@@ -9840,7 +9857,7 @@
         "chain-function": "1.0.0",
         "dom-helpers": "3.2.1",
         "loose-envify": "1.3.1",
-        "prop-types": "15.5.10",
+        "prop-types": "15.6.0",
         "warning": "3.0.0"
       }
     },
@@ -9962,6 +9979,15 @@
           "version": "2.4.1",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
           "integrity": "sha1-TekR5mew6ukSTjQlS1OupvxhjT4="
+        },
+        "prop-types": {
+          "version": "15.5.10",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.5.10.tgz",
+          "integrity": "sha1-J5ffwxJhguOpXj37suiT3ddFYVQ=",
+          "requires": {
+            "fbjs": "0.8.12",
+            "loose-envify": "1.3.1"
+          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "express-session": "^1.15.3",
     "jwt-decode": "^2.2.0",
     "path": "^0.12.7",
+    "prop-types": "^15.6.0",
     "react": "^15.6.1",
     "react-dom": "^15.6.1",
     "react-redux": "^5.0.5",

--- a/src/components/Test.js
+++ b/src/components/Test.js
@@ -7,7 +7,11 @@ export default (props) => {
   return (
     <div>
       <h1>This is a test</h1>
-      <button onClick={props.loginRequest}>Login</button>
+      <p>props.auth = {props.auth}</p>
+      <button onClick={() => {
+          props.authService.login();
+          props.loginRequest();
+        }}>Login</button>
     </div>
   )
 }

--- a/src/components/Test.js
+++ b/src/components/Test.js
@@ -12,6 +12,11 @@ export default (props) => {
           props.authService.login();
           props.loginRequest();
         }}>Login</button>
+
+      <button onClick={() => {
+          props.logoutSuccess();
+          props.authService.logout();
+        }}>Log out</button>
     </div>
   )
 }

--- a/src/components/Test.js
+++ b/src/components/Test.js
@@ -1,9 +1,13 @@
 // This component just used for testing.
-// Not sure if having components in this directory is correct. Need to check with team. - Luke.
 import React from 'react';
 
 export default (props) => {
+  console.log('Test props:');
+  console.log(props);
   return (
-    <h1>This is a test</h1>
+    <div>
+      <h1>This is a test</h1>
+      <button onClick={props.loginRequest}>Login</button>
+    </div>
   )
 }

--- a/src/components/Test.js
+++ b/src/components/Test.js
@@ -1,5 +1,6 @@
 // This component just used for testing.
 import React from 'react';
+import AuthService from '../utils/AuthService'
 
 export default (props) => {
   console.log('Test props:');
@@ -15,7 +16,7 @@ export default (props) => {
 
       <button onClick={() => {
           props.logoutSuccess();
-          props.authService.logout();
+          AuthService.logout();
         }}>Log out</button>
     </div>
   )

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -8,7 +8,7 @@ import Main from './Main';
 
 const mapStateToProps = (state) => {
   return {
-    isAuthenticated: false
+    auth: state.auth
   }
 }
 

--- a/src/containers/Main.js
+++ b/src/containers/Main.js
@@ -46,7 +46,7 @@ class Main extends React.Component {
         </nav>
         <div>
           <Route exact path="/" component={() => <p>'hello world'</p>} {...this.props}/>
-          <PropsRoute path="/test" component={Test} {...this.props}/>
+          <PropsRoute path="/test" component={Test} authService={this.authService} {...this.props}/>
           <Route path="/OnBoardFlow" component={OnBoardFlow}/>
         </div>
       </div>

--- a/src/containers/Main.js
+++ b/src/containers/Main.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Route, Link } from 'react-router-dom'
-// import PropsRoute from '../utils/PropsRoute';
 
 /* Import components */
 import Test from '../components/Test';

--- a/src/containers/Main.js
+++ b/src/containers/Main.js
@@ -15,6 +15,33 @@ class Main extends React.Component {
     this.authService = new AuthService();
   }
 
+  componentWillMount() {
+    // Add callback for lock's `authenticated` event
+    console.log('this.authService.lock')
+    console.log(this.authService.lock)
+    this.authService.lock.on('authenticated', (authResult) => {
+      console.log('AUTHENTICATED EVENT FIRED ON authService.lock')
+      console.log('authResult')
+      console.log(authResult)
+      this.authService.lock.getProfile(authResult.idToken, (error, profile) => {
+        console.log('profile')
+        console.log(profile)
+        console.log('error')
+        console.log(error)
+        if (error) { return this.props.loginError(error); }
+        AuthService.setToken(authResult.idToken); // static method
+        AuthService.setProfile(profile); // static method
+        this.props.loginSuccess(profile);
+        return this.props.history.push({ pathname: '/' });
+      });
+    });
+    // Add callback for lock's `authorization_error` event
+    this.authService.lock.on('authorization_error', (error) => {
+      this.props.loginError(error);
+      return this.props.history.push({ pathname: '/' });
+    });
+  }
+
   render() {
     console.log('this.props from Main')
     console.log(this.props)

--- a/src/containers/Main.js
+++ b/src/containers/Main.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Route, Link } from 'react-router-dom'
+// import PropsRoute from '../utils/PropsRoute';
 
 /* Import components */
 import Test from '../components/Test';
@@ -26,5 +27,7 @@ class Main extends React.Component {
     )
   }
 }
+
+Main.contextTypes = { store: React.PropTypes.object };
 
 export default Main;

--- a/src/containers/Main.js
+++ b/src/containers/Main.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Route, Link } from 'react-router-dom'
+import PropsRoute from '../utils/PropsRoute';
 
 /* Import components */
 import Test from '../components/Test';
@@ -19,7 +20,7 @@ class Main extends React.Component {
         </nav>
         <div>
           <Route exact path="/" component={() => <p>'hello world'</p>} {...this.props}/>
-          <Route path="/test" component={Test} {...this.props}/>
+          <PropsRoute path="/test" component={Test} {...this.props}/>
           <Route path="/OnBoardFlow" component={OnBoardFlow}/>
         </div>
       </div>

--- a/src/containers/Main.js
+++ b/src/containers/Main.js
@@ -17,17 +17,8 @@ class Main extends React.Component {
 
   componentWillMount() {
     // Add callback for lock's `authenticated` event
-    console.log('this.authService.lock')
-    console.log(this.authService.lock)
     this.authService.lock.on('authenticated', (authResult) => {
-      console.log('AUTHENTICATED EVENT FIRED ON authService.lock')
-      console.log('authResult')
-      console.log(authResult)
       this.authService.lock.getProfile(authResult.idToken, (error, profile) => {
-        console.log('profile')
-        console.log(profile)
-        console.log('error')
-        console.log(error)
         if (error) { return this.props.loginError(error); }
         AuthService.setToken(authResult.idToken); // static method
         AuthService.setProfile(profile); // static method

--- a/src/containers/Main.js
+++ b/src/containers/Main.js
@@ -1,12 +1,20 @@
 import React from 'react';
 import { Route, Link } from 'react-router-dom'
 import PropsRoute from '../utils/PropsRoute';
+import PropTypes from 'prop-types';
 
 /* Import components */
 import Test from '../components/Test';
 import OnBoardFlow from './OnBoardFlow';
+import AuthService from '../utils/AuthService';
 
 class Main extends React.Component {
+  constructor() {
+    super()
+    //instantiate the authService from class
+    this.authService = new AuthService();
+  }
+
   render() {
     console.log('this.props from Main')
     console.log(this.props)
@@ -28,6 +36,6 @@ class Main extends React.Component {
   }
 }
 
-Main.contextTypes = { store: React.PropTypes.object };
+Main.contextTypes = { store: PropTypes.object };
 
 export default Main;

--- a/src/redux/modules/auth.js
+++ b/src/redux/modules/auth.js
@@ -1,11 +1,12 @@
 import AuthService from '../../utils/AuthService'
 import * as types from '../../utils/types';
 
-const authEpic = action$ => {
-  return action$.ofType('LOGIN_REQUEST')
-    // .delay(1000)
-    .mapTo({ type: 'LOGIN_ERROR'})
-}
+//
+// const authEpic = action$ => {
+//   return action$.ofType('LOGIN_REQUEST')
+//     .delay(7000)
+//     .mapTo({ type: 'LOGIN_ERROR'})
+// }
 
 const authReducer = (state = {
   isAuthenticated: !AuthService.isTokenExpired(),
@@ -50,5 +51,5 @@ const authReducer = (state = {
 
 export {
   authReducer as default,
-  authEpic
+  // authEpic
 }

--- a/src/redux/modules/auth.js
+++ b/src/redux/modules/auth.js
@@ -3,8 +3,8 @@ import * as types from '../../utils/types';
 
 const authEpic = action$ => {
   return action$.ofType('LOGIN_REQUEST')
-    .delay(1000)
-    .mapTo({ type: 'LOGIN_SUCCESS'})
+    // .delay(1000)
+    .mapTo({ type: 'LOGIN_ERROR'})
 }
 
 const authReducer = (state = {
@@ -15,14 +15,14 @@ const authReducer = (state = {
 }, action) => {
   switch (action.type) {
     case types.LOGIN_REQUEST:
-      var x = new AuthService   //HACK
-      x.login()                 //HACK
+      console.log('firing LOGIN_REQUEST from auth.js module')
       return {
         ...state,
         isFetching: true,
         error: null,
       };
     case types.LOGIN_SUCCESS:
+      console.log('firing LOGIN_SUCCESS from auth.js module')
       return {
         ...state,
         isFetching: false,

--- a/src/redux/modules/root.js
+++ b/src/redux/modules/root.js
@@ -15,7 +15,7 @@ import onBoardingReducer, { onBoardingEpic } from './onBoarding'
 export const rootEpic = combineEpics(
   /* epics */
   exampleEpic,
-  authEpic
+  // authEpic
 )
 
 export const rootReducer = combineReducers({

--- a/src/utils/AuthService.js
+++ b/src/utils/AuthService.js
@@ -34,7 +34,7 @@ export default class AuthService {
     return !!token && !AuthService.isTokenExpired(token);
   }
 
-  logout() {
+  static logout() {
     // Clear user token and profile data from window.localStorage
     window.localStorage.removeItem('id_token');
     window.localStorage.removeItem('profile');

--- a/src/utils/AuthService.js
+++ b/src/utils/AuthService.js
@@ -9,7 +9,7 @@ export default class AuthService {
     this.lock = new Auth0Lock(config.AUTH0_CLIENT_ID, config.AUTH0_DOMAIN, {
       auth: {
         redirectUrl: config.REDIRECT_URL,
-        responseType: 'token',
+        responseType: 'id_token',
       },
     });
 
@@ -22,7 +22,6 @@ export default class AuthService {
   // ======================================================
   login() {
     // Call the show method to display the widget.
-    console.log('AuthService login function fired')
     this.lock.show();
   }
 
@@ -35,7 +34,7 @@ export default class AuthService {
     return !!token && !AuthService.isTokenExpired(token);
   }
 
-  static logout() {
+  logout() {
     // Clear user token and profile data from window.localStorage
     window.localStorage.removeItem('id_token');
     window.localStorage.removeItem('profile');
@@ -76,6 +75,7 @@ export default class AuthService {
   }
 
   static isTokenExpired() {
+    console.log('checking isTokenExpired')
     const token = AuthService.getToken();
     if (!token) return true;
     const date = AuthService.getTokenExpirationDate();

--- a/src/utils/PropsRoute.js
+++ b/src/utils/PropsRoute.js
@@ -1,0 +1,24 @@
+// We will use PropsRoute to replace React Router 4's <Route> component, so that we can pass props through
+// as we would a normal component.
+//
+// See https://github.com/ReactTraining/react-router/issues/4105#issuecomment-289195202
+
+import React from 'react';
+import {Route} from 'react-router-dom';
+
+const renderMergedProps = (component, ...rest) => {
+  const finalProps = Object.assign({}, ...rest);
+  return (
+    React.createElement(component, finalProps)
+  );
+}
+
+const PropsRoute = ({ component, ...rest }) => {
+  return (
+    <Route {...rest} render={routeProps => {
+      return renderMergedProps(component, routeProps, rest);
+    }}/>
+  );
+}
+
+export default PropsRoute;

--- a/yarn.lock
+++ b/yarn.lock
@@ -47,13 +47,9 @@ acorn@^5.0.0, acorn@^5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.1.2.tgz#911cb53e036807cf0fa778dc5d370fbd864246d7"
 
-address@1.0.2:
+address@1.0.2, address@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/address/-/address-1.0.2.tgz#480081e82b587ba319459fef512f516fe03d58af"
-
-address@^1.0.1:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/address/-/address-1.0.3.tgz#b5f50631f8d6cec8bd20c963963afb55e06cbce9"
 
 ajv-keywords@^1.0.0, ajv-keywords@^1.1.1:
   version "1.5.1"
@@ -66,7 +62,7 @@ ajv@^4.7.0, ajv@^4.9.1:
     co "^4.6.0"
     json-stable-stringify "^1.0.1"
 
-ajv@^5.0.0, ajv@^5.1.0:
+ajv@^5.0.0:
   version "5.2.3"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.2.3.tgz#c06f598778c44c6b161abafe3466b81ad1814ed2"
   dependencies:
@@ -338,11 +334,7 @@ aws-sign2@~0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.6.0.tgz#14342dd38dbcc94d0e5b87d763cd63612c0e794f"
 
-aws-sign2@~0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
-
-aws4@^1.2.1, aws4@^1.6.0:
+aws4@^1.2.1:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.6.0.tgz#83ef5ca860b2b32e4a0deedee8c771b9db57471e"
 
@@ -368,7 +360,7 @@ babel-code-frame@^6.11.0, babel-code-frame@^6.16.0, babel-code-frame@^6.22.0, ba
     esutils "^2.0.2"
     js-tokens "^3.0.2"
 
-babel-core@6.25.0:
+babel-core@6.25.0, babel-core@^6.0.0:
   version "6.25.0"
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.25.0.tgz#7dd42b0463c742e9d5296deb3ec67a9322dad729"
   dependencies:
@@ -392,7 +384,7 @@ babel-core@6.25.0:
     slash "^1.0.0"
     source-map "^0.5.0"
 
-babel-core@^6.0.0, babel-core@^6.26.0:
+babel-core@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.26.0.tgz#af32f78b31a6fcef119c87b0fd8d9753f03a0bb8"
   dependencies:
@@ -879,17 +871,11 @@ babel-plugin-transform-react-jsx@6.24.1, babel-plugin-transform-react-jsx@^6.24.
     babel-plugin-syntax-jsx "^6.8.0"
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-regenerator@6.24.1:
+babel-plugin-transform-regenerator@6.24.1, babel-plugin-transform-regenerator@^6.22.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.24.1.tgz#b8da305ad43c3c99b4848e4fe4037b770d23c418"
   dependencies:
     regenerator-transform "0.9.11"
-
-babel-plugin-transform-regenerator@^6.22.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz#e0703696fbde27f0a3efcacf8b4dca2f7b3a8f2f"
-  dependencies:
-    regenerator-transform "^0.10.0"
 
 babel-plugin-transform-runtime@6.23.0:
   version "6.23.0"
@@ -998,14 +984,14 @@ babel-register@^6.24.1, babel-register@^6.26.0:
     mkdirp "^0.5.1"
     source-map-support "^0.4.15"
 
-babel-runtime@6.23.0:
+babel-runtime@6.23.0, babel-runtime@^6.22.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.23.0.tgz#0a9489f144de70efb3ce4300accdb329e2fc543b"
   dependencies:
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
 
-babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.26.0:
+babel-runtime@^6.18.0, babel-runtime@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
   dependencies:
@@ -1132,18 +1118,6 @@ boom@2.x.x:
   resolved "https://registry.yarnpkg.com/boom/-/boom-2.10.1.tgz#39c8918ceff5799f83f9492a848f625add0c766f"
   dependencies:
     hoek "2.x.x"
-
-boom@4.x.x:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/boom/-/boom-4.3.1.tgz#4f8a3005cb4a7e3889f749030fd25b96e01d2e31"
-  dependencies:
-    hoek "4.x.x"
-
-boom@5.x.x:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/boom/-/boom-5.2.0.tgz#5dd9da6ee3a5f302077436290cb717d3f4a54e02"
-  dependencies:
-    hoek "4.x.x"
 
 boxen@^0.6.0:
   version "0.6.0"
@@ -1640,7 +1614,7 @@ cookiejar@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.1.tgz#41ad57b1b555951ec171412a81942b1e8200d34a"
 
-core-js@2.4.1:
+core-js@2.4.1, core-js@^2.4.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.4.1.tgz#4de911e667b0eae9124e34254b53aea6fc618d3e"
 
@@ -1648,7 +1622,7 @@ core-js@^1.0.0:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
 
-core-js@^2.4.0, core-js@^2.5.0:
+core-js@^2.5.0:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.1.tgz#ae6874dc66937789b80754ff5428df66819ca50b"
 
@@ -1726,12 +1700,6 @@ cryptiles@2.x.x:
   resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-2.0.5.tgz#3bdfecdc608147c1c67202fa291e7dca59eaa3b8"
   dependencies:
     boom "2.x.x"
-
-cryptiles@3.x.x:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-3.1.2.tgz#a89fbb220f5ce25ec56e8c4aa8a4fd7b5b0d29fe"
-  dependencies:
-    boom "5.x.x"
 
 crypto-browserify@^3.11.0:
   version "3.11.1"
@@ -2598,7 +2566,7 @@ express@^4.13.3, express@^4.15.3:
     utils-merge "1.0.1"
     vary "~1.1.2"
 
-extend@^3.0.0, extend@~3.0.0, extend@~3.0.1:
+extend@^3.0.0, extend@~3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
 
@@ -2806,7 +2774,7 @@ forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
 
-form-data@^2.3.1, form-data@~2.3.1:
+form-data@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.1.tgz#6fb94fbd71885306d73d15cc497fe4cc4ecd44bf"
   dependencies:
@@ -3040,23 +3008,12 @@ har-schema@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-1.0.5.tgz#d263135f43307c02c602afc8fe95970c0151369e"
 
-har-schema@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92"
-
 har-validator@~4.2.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-4.2.1.tgz#33481d0f1bbff600dd203d75812a6a5fba002e2a"
   dependencies:
     ajv "^4.9.1"
     har-schema "^1.0.5"
-
-har-validator@~5.0.3:
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.0.3.tgz#ba402c266194f15956ef15e0fcf242993f6a7dfd"
-  dependencies:
-    ajv "^5.1.0"
-    har-schema "^2.0.0"
 
 has-ansi@^2.0.0:
   version "2.0.0"
@@ -3111,15 +3068,6 @@ hawk@3.1.3, hawk@~3.1.3:
     hoek "2.x.x"
     sntp "1.x.x"
 
-hawk@~6.0.2:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/hawk/-/hawk-6.0.2.tgz#af4d914eb065f9b5ce4d9d11c1cb2126eecc3038"
-  dependencies:
-    boom "4.x.x"
-    cryptiles "3.x.x"
-    hoek "4.x.x"
-    sntp "2.x.x"
-
 he@1.1.x:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
@@ -3145,10 +3093,6 @@ hmac-drbg@^1.0.0:
 hoek@2.x.x:
   version "2.16.3"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"
-
-hoek@4.x.x:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.0.tgz#72d9d0754f7fe25ca2d01ad8f8f9a9449a89526d"
 
 hoist-non-react-statics@^2.2.1, hoist-non-react-statics@^2.3.0, hoist-non-react-statics@^2.3.1:
   version "2.3.1"
@@ -3265,14 +3209,6 @@ http-signature@~1.1.0:
   resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.1.1.tgz#df72e267066cd0ac67fb76adf8e134a8fbcf91bf"
   dependencies:
     assert-plus "^0.2.0"
-    jsprim "^1.2.2"
-    sshpk "^1.7.0"
-
-http-signature@~1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.2.0.tgz#9aecd925114772f3d95b65a60abb8f7c18fbace1"
-  dependencies:
-    assert-plus "^1.0.0"
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
@@ -4378,17 +4314,13 @@ minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@0.0.8:
+minimist@0.0.8, minimist@~0.0.1:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
 minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
-
-minimist@~0.0.1:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
 
 mkdirp@0.5.1, mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
   version "0.5.1"
@@ -4576,7 +4508,7 @@ number-is-nan@^1.0.0:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/nwmatcher/-/nwmatcher-1.4.2.tgz#c5e545ab40d22a56b0326531c4beaed7a888b3ea"
 
-oauth-sign@~0.8.1, oauth-sign@~0.8.2:
+oauth-sign@~0.8.1:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
 
@@ -5206,15 +5138,9 @@ progress@^1.1.8:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/progress/-/progress-1.1.8.tgz#e260c78f6161cdd9b0e56cc3e0a85de17c7a57be"
 
-promise@7.1.1:
+promise@7.1.1, promise@^7.0.3, promise@^7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/promise/-/promise-7.1.1.tgz#489654c692616b8aa55b0724fa809bb7db49c5bf"
-  dependencies:
-    asap "~2.0.3"
-
-promise@^7.0.3, promise@^7.1.1:
-  version "7.3.1"
-  resolved "https://registry.yarnpkg.com/promise/-/promise-7.3.1.tgz#064b72602b18f90f29192b8b1bc418ffd1ebd3bf"
   dependencies:
     asap "~2.0.3"
 
@@ -5270,7 +5196,7 @@ q@^1.1.2:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.0.tgz#dd01bac9d06d30e6f219aecb8253ee9ebdc308f1"
 
-qs@6.5.1, qs@^6.4.0, qs@^6.5.1, qs@~6.5.1:
+qs@6.5.1, qs@^6.4.0, qs@^6.5.1:
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
 
@@ -5693,14 +5619,6 @@ regenerator-transform@0.9.11:
     babel-types "^6.19.0"
     private "^0.1.6"
 
-regenerator-transform@^0.10.0:
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/regenerator-transform/-/regenerator-transform-0.10.1.tgz#1e4996837231da8b7f3cf4114d71b5691a0680dd"
-  dependencies:
-    babel-runtime "^6.18.0"
-    babel-types "^6.19.0"
-    private "^0.1.6"
-
 regex-cache@^0.4.2:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/regex-cache/-/regex-cache-0.4.4.tgz#75bdc58a2a1496cec48a12835bc54c8d562336dd"
@@ -5778,7 +5696,7 @@ repeating@^2.0.0:
   dependencies:
     is-finite "^1.0.0"
 
-request@2.81.0:
+request@2.81.0, request@^2.79.0:
   version "2.81.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.81.0.tgz#c6928946a0e06c5f8d6f8a9333469ffda46298a0"
   dependencies:
@@ -5804,33 +5722,6 @@ request@2.81.0:
     tough-cookie "~2.3.0"
     tunnel-agent "^0.6.0"
     uuid "^3.0.0"
-
-request@^2.79.0:
-  version "2.83.0"
-  resolved "https://registry.yarnpkg.com/request/-/request-2.83.0.tgz#ca0b65da02ed62935887808e6f510381034e3356"
-  dependencies:
-    aws-sign2 "~0.7.0"
-    aws4 "^1.6.0"
-    caseless "~0.12.0"
-    combined-stream "~1.0.5"
-    extend "~3.0.1"
-    forever-agent "~0.6.1"
-    form-data "~2.3.1"
-    har-validator "~5.0.3"
-    hawk "~6.0.2"
-    http-signature "~1.2.0"
-    is-typedarray "~1.0.0"
-    isstream "~0.1.2"
-    json-stringify-safe "~5.0.1"
-    mime-types "~2.1.17"
-    oauth-sign "~0.8.2"
-    performance-now "^2.1.0"
-    qs "~6.5.1"
-    safe-buffer "^5.1.1"
-    stringstream "~0.0.5"
-    tough-cookie "~2.3.3"
-    tunnel-agent "^0.6.0"
-    uuid "^3.1.0"
 
 require-directory@^2.1.1:
   version "2.1.1"
@@ -6122,12 +6013,6 @@ sntp@1.x.x:
   dependencies:
     hoek "2.x.x"
 
-sntp@2.x.x:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/sntp/-/sntp-2.0.2.tgz#5064110f0af85f7cfdb7d6b67a40028ce52b4b2b"
-  dependencies:
-    hoek "4.x.x"
-
 sockjs-client@1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/sockjs-client/-/sockjs-client-1.1.2.tgz#f0212a8550e4c9468c8cceaeefd2e3493c033ad5"
@@ -6314,7 +6199,7 @@ string_decoder@~1.0.3:
   dependencies:
     safe-buffer "~5.1.0"
 
-stringstream@~0.0.4, stringstream@~0.0.5:
+stringstream@~0.0.4:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/stringstream/-/stringstream-0.0.5.tgz#4e484cd4de5a0bbbee18e46307710a8a81621878"
 
@@ -6536,7 +6421,7 @@ toposort@^1.0.0:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/toposort/-/toposort-1.0.6.tgz#c31748e55d210effc00fdcdc7d6e68d7d7bb9cec"
 
-tough-cookie@^2.3.2, tough-cookie@~2.3.0, tough-cookie@~2.3.3:
+tough-cookie@^2.3.2, tough-cookie@~2.3.0:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.3.tgz#0b618a5565b6dea90bf3425d04d55edc475a7561"
   dependencies:
@@ -6744,7 +6629,7 @@ uuid@^2.0.1, uuid@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-2.0.3.tgz#67e2e863797215530dff318e5bf9dcebfd47b21a"
 
-uuid@^3.0.0, uuid@^3.1.0:
+uuid@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
 
@@ -6968,13 +6853,9 @@ window-size@0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.1.0.tgz#5438cd2ea93b202efa3a19fe8887aee7c94f9c9d"
 
-wordwrap@0.0.2:
+wordwrap@0.0.2, wordwrap@~0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.2.tgz#b79669bb42ecb409f83d583cad52ca17eaa1643f"
-
-wordwrap@~0.0.2:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.3.tgz#a3d5da6cd5c0bc0008d37234bbaf1bed63059107"
 
 wordwrap@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This PR adds a PropsRoute utility component to take RR4's Route and allow us to pass props to the component as we might normally.

Authentication now works, token and profile are saved to localStorage. 

/test now has a login and logout button.