### PR TITLE
Add neo4j service to docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     image: 'tbd_web'
     ports:
       - 3000:3000
+      - 4000:4000
     volumes:
       - type: bind
         source: ./

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,3 +11,13 @@ services:
       - type: bind
         source: ./
         target: /wwwroot
+
+  neo4j:
+    image: 'neo4j'
+    ports:
+      - 7474:7474
+      - 7687:7687
+    volumes:
+      - type: volume
+        source: ${HOME}/neo4j/data
+        target: /data


### PR DESCRIPTION
This PR adds a neo4j service to the docker-compose.yml. It has a bind-mount to the $HOME/neo4j directory on your machine. This means that the data you create in the container will persist on your machine even after you destroy the container and create a new one.

This PR also fixes a small issue where port 4000 (Node server) was not being exposed from the webapp service. 

Now might be a good time to stop using "npm start" and start using "docker-compose up -d", as the latter will start both the app and the neo4j DB.