### PR TITLE
Squash auth bugs

### DIFF
--- a/client/src/components/Callback.js
+++ b/client/src/components/Callback.js
@@ -12,17 +12,12 @@ class Callback extends React.Component {
     this.checkUser();
   }
 
-  // componentWillReceiveProps(nextProps) {
-  //   console.log("nextProps in Callback.js")
-  //   console.log(nextProps);
-  //   this.checkUser();
-  // }
-
   checkUser() {
     const {authService} = this.props
     this.props.loginRequest()
     this.handleAuthentication().then(profile => {
       if (authService.isAuthenticated()) {
+        this.props.getUser(profile);
         this.props.loginSuccess(profile);
       } else {
         this.props.loginError({error: "something went wrong."});

--- a/client/src/components/ProfileSideCard.js
+++ b/client/src/components/ProfileSideCard.js
@@ -5,7 +5,6 @@ import lnLogo from '../assets/lnLogo.png';
 
 function ProfileSideCard(props) {
   const { name, email, picture } = props;
-  console.log(name, picture)
   return (
     <div className="col s7">
       <img className="profile-image"src={picture}/>

--- a/client/src/containers/App.js
+++ b/client/src/containers/App.js
@@ -77,7 +77,7 @@ class App extends React.Component {
                 <Redirect to="/landingPage"/>
               )
             )}/>
-            <Route path="/dashboard" render={(props) =>  <Dashboard {...props} authService={this.authService}/>} />
+            <Route path="/dashboard" render={(props) =>  <Dashboard {...props} user={this.props.user} authService={this.authService}/>} />
             <Route exact path="/landingPage" component={LandingPage} />
             <Route path="/callback" render={(props) => <Callback {...props} {...this.props} /> }/>
           </div>

--- a/client/src/containers/Dashboard.js
+++ b/client/src/containers/Dashboard.js
@@ -41,10 +41,11 @@ class Dashboard extends Component {
   // }
 
   componentDidMount() {
+    console.log(this.props);
     const { authService, getUser } = this.props;
 
     if (authService.isAuthenticated()) {
-      getUser(authService.getProfile())
+      getUser(this.props.auth.profile)
     }
   }
 

--- a/client/src/containers/Dashboard.js
+++ b/client/src/containers/Dashboard.js
@@ -30,18 +30,7 @@ class Dashboard extends Component {
     super(props);
   }
 
-  // componentWillMount() {
-  //   // getUser tries to get the user, and if it doesn't get a user, will try addUser
-  //   console.log('this.props.auth in Dashboard')
-  //   console.log(this.props.auth)
-  //   setTimeout(_ => this.props.getUser(this.props.auth.profile.name), 3000)
-  //   // if (this.props.auth.profile.name) {
-  //     // this.props.getUser(this.props.auth.profile.name);
-  //   // }
-  // }
-
   componentDidMount() {
-    console.log(this.props);
     const { authService, getUser } = this.props;
 
     if (authService.isAuthenticated()) {
@@ -50,8 +39,8 @@ class Dashboard extends Component {
   }
 
   render() {
-    const { auth, match } = this.props;
-    return auth.profile.name ? (
+    const { auth, match, user } = this.props;
+    return user ? (
         <div>
           <Route path={`${match.path}/onBoardFlow`} component={OnBoardFlow}/>
           <Route path={`${match.path}/profile`} component={Profile}/>

--- a/client/src/containers/OnBoardFlow.js
+++ b/client/src/containers/OnBoardFlow.js
@@ -39,23 +39,23 @@ class OnBoardFlow extends Component {
   render() {
     const { match } = this.props
     return (
-      <div>  
-        <Route 
+      <div>
+        <Route
           exact
-          path={`${match.path}/`} 
+          path={`${match.path}/`}
           component={() => (
             <ContactForm onSubmit={this.handleContactSubmit}/>
           )}
         />
-        <Route 
-          path={`${match.path}/locationInfo`} 
+        <Route
+          path={`${match.path}/locationInfo`}
           component={ () => (
-            <LocationForm 
+            <LocationForm
               options={this.options}
               selectValue={this.selectValue}
               handleLocationSubmit={this.handleLocationSubmit}
             />
-          )} 
+          )}
         />
       </div>
 
@@ -76,4 +76,3 @@ function mapDispatchToProps(dispatch) {
 }
 
 export default withRouter(connect(mapStateToProps, mapDispatchToProps)(OnBoardFlow))
-

--- a/client/src/containers/ProfileSkillCard.js
+++ b/client/src/containers/ProfileSkillCard.js
@@ -21,7 +21,6 @@ class ProfileSkillCard extends Component {
 
   constructor(props) {
     super(props);
-    console.log(props)
     this.identity = this.props.identity? this.props.identity : 7135;
     this.state = {
       expanded: false,
@@ -35,7 +34,6 @@ class ProfileSkillCard extends Component {
 
   componentDidMount() {
     // this.props.getSkills(this.identity);
-    console.log(this.props.skills)
   }
 
   openAddSkillBox() {
@@ -51,17 +49,17 @@ class ProfileSkillCard extends Component {
     return (
       <div>
 
-        <AddSkillBox 
+        <AddSkillBox
           open={this.state.skillBoxOpen}
           identity={this.identity}
           closeAddSkillBox={this.closeAddSkillBox.bind(this)}
           addSkill={this.props.addSkill}
           skills={this.props.skills.list.map(({ properties }) => properties.name)}
         />
-        <ProfileSkillWrapper 
+        <ProfileSkillWrapper
           expanded={this.state.expanded}
           openAddSkillBox={this.openAddSkillBox.bind(this)}
-        > 
+        >
           { this.props.skills.list.map((skill) => <SkillListItem { ...skill }/>) }
         </ProfileSkillWrapper>
       </div>

--- a/client/src/redux/actions/actionCreators.js
+++ b/client/src/redux/actions/actionCreators.js
@@ -48,9 +48,12 @@ export function getSkillsFullfilled(skills) {
 }
 
 export function getUser(profile) {
+  if (typeof profile === 'string') {
+    profile = JSON.parse(profile)
+  }
   return {
     type: types.GET_USER,
-    payload: profile.name
+    payload: profile.sub
   }
 }
 

--- a/client/src/redux/modules/user.js
+++ b/client/src/redux/modules/user.js
@@ -1,8 +1,5 @@
 import { ajax } from 'rxjs/observable/dom/ajax';
 
-// import { Observable } from 'rxjs/Observable';
-// import 'rxjs/add/observable/dom/ajax';
-
 import { getUserFulfilled, addUser } from './../actions/actionCreators';
 import * as types from '../../utils/types';
 
@@ -12,17 +9,15 @@ const getUserEpic = (action$, state) => {
   return action$
     .ofType(types.GET_USER)
     .mergeMap(action => {
-      return ajax.getJSON(`/api/contractor/?name=${action.payload}`)
+      return ajax.getJSON(`/api/contractor/?sub=${action.payload}`)
     })
     .map(profile => {
       //If no profile is returned from server, use locally stored auth.profile to addUser
-      if (!profile) {
+      if (!profile || profile.error) {
         profile = auth.profile
-        // const profileStr = window.localStorage.getItem('profile');
-        // profile = JSON.parse(profileStr);
         return addUser(profile);
       }
-      return !profile.error ? getUserFulfilled(profile) : addUser(profile)
+      return getUserFulfilled(profile);
     })
 }
 

--- a/client/src/redux/modules/user.js
+++ b/client/src/redux/modules/user.js
@@ -12,7 +12,7 @@ const getUserEpic = (action$, state) => {
   return action$
     .ofType(types.GET_USER)
     .mergeMap(action => {
-      return ajax.getJSON(`/api/contractor/?name=${auth.profile.name}`)
+      return ajax.getJSON(`/api/contractor/?name=${action.payload}`)
     })
     .map(profile => {
       //If no profile is returned from server, use locally stored auth.profile to addUser


### PR DESCRIPTION
This PR squashes some annoying auth bugs that were happening on login. 
Now, when you login, you should be automatically redirected to /dashboard/profile and you should see your profile information. If the account didn't exist in the DB, a node will be created.
Also, we now get the user node that corresponds to the profile.sub property (before we were using profile.name, which is obviously prone to issues as two people might have the same name). The "sub" property returned from auth0 should be unique to the google account that gave the app access on sign-in.
Lastly, this PR deletes the "userActions.js" file which was duplication from the "actionCreators.js" file.