### PR TITLE
Add API method for creating teams

### DIFF
--- a/server/database/graphApi.js
+++ b/server/database/graphApi.js
@@ -215,13 +215,13 @@ class GraphApi {
   }
 
   createTeam(reqBody) {
-    const { teamName, locationName, projectName } = reqBody;
+    const { teamName, locationId, projectId } = reqBody;
 
     const session = this.driver.session();
     return session
       .run(`
-        MATCH (location:Location {name: '${locationName}'})
-        MATCH (project:Project {name: '${projectName}'})
+        MATCH (location:Location) where id(location) = ${locationId}
+        MATCH (project:Project) where id(project) = ${projectId}
         CREATE (team:Team {name: '${teamName}', created_at: '${new Date()}'})-[:HAS_LOCATION]->(location),
         (team)-[:TEAM_FOR]->(project)
         RETURN team

--- a/server/database/graphApi.js
+++ b/server/database/graphApi.js
@@ -237,6 +237,46 @@ class GraphApi {
         console.error(err)
       });
   }
+
+  addContractorToTeam(reqBody) {
+    const {contractorId, teamId} = reqBody;
+    const session = this.driver.session();
+    return session
+      .run(`
+        MATCH (team:Team) where id(team) = ${teamId}
+        MATCH (c:Contractor) where id(c) = ${contractorId}
+        CREATE UNIQUE (c)-[:IS_MEMBER_OF]->(team)
+        RETURN c
+      `)
+      .then(result => {
+        const { records } = result;
+        session.close();
+        return result
+      })
+      .catch(err => {
+        console.error(err)
+      });
+  }
+
+  removeContractorFromTeam(reqBody) {
+    const {contractorId, teamId} = reqBody;
+    const session = this.driver.session();
+    return session
+      .run(`
+        MATCH (team:Team) where id(team) = ${teamId}
+        MATCH (c:Contractor) where id(c) = ${contractorId}
+        MATCH (c)-[r:IS_MEMBER_OF]->(team)
+        delete r
+      `)
+      .then(result => {
+        const { records } = result;
+        session.close();
+        return result
+      })
+      .catch(err => {
+        console.error(err)
+      });
+  }
 }
 
 module.exports = GraphApi;

--- a/server/database/graphApi.js
+++ b/server/database/graphApi.js
@@ -177,7 +177,7 @@ class GraphApi {
       })
   }
 
-  addContractorExpirience(identity, experience) {
+  addContractorExperience(identity, experience) {
     const session = this.driver.session();
     return session
       .run(`
@@ -198,9 +198,9 @@ class GraphApi {
       .catch(err => console.error(err))
   }
 
-  getContractorExpirience(identity) {
+  getContractorExperience(identity) {
     const session = this.driver.session();
-    return session  
+    return session
       .run(`
         MATCH (cont:Contractor) WHERE ID(cont) = ${identity}
         MATCH (cont)-[:HAS_EXPERIENCE]->(exp)
@@ -212,6 +212,30 @@ class GraphApi {
         return extractNodes(records);
       })
       .catch(err => console.error(err));
+  }
+
+  createTeam(reqBody) {
+    const { teamName, locationName, projectName } = reqBody;
+
+    const session = this.driver.session();
+    return session
+      .run(`
+        MATCH (location:Location {name: '${locationName}'})
+        MATCH (project:Project {name: '${projectName}'})
+        CREATE (team:Team {name: '${teamName}', created_at: '${new Date()}'})-[:HAS_LOCATION]->(location),
+        (team)-[:TEAM_FOR]->(project)
+        RETURN team
+      `)
+      .then(result => {
+        const { records } = result;
+        session.close();
+        return records.length
+          ? extractNodes(records)
+          : {"error": "An error occurred. This team was not created."};
+      })
+      .catch(err => {
+        console.error(err)
+      });
   }
 }
 

--- a/server/database/startUpCypherScript.js
+++ b/server/database/startUpCypherScript.js
@@ -1,5 +1,5 @@
 const startUpScript = `
-  CREATE 
+  CREATE
   (cont:Contractor {email: "robJohnson@gmail.com", name: "Rob Johnson"}),
   (s1:Skill {name: "Leadership"}),
   (s2:Skill {name: "Teamwork"}),
@@ -9,7 +9,9 @@ const startUpScript = `
   (c1:Certification {name: "Forklift Driver"}),
   (c2:Certification {name: "Welding"}),
   (c3:Certification {name: "Warehouse Safety"}),
-  (c4:Certification {name: "First Aid"})
+  (c4:Certification {name: "First Aid"}),
+  (p:Project {name: "Deathstar"}),
+  (l:Location {name: "Alderaan"})
   RETURN s1
 `
 const massDelete = `

--- a/server/routers/contractorExperienceRouter.js
+++ b/server/routers/contractorExperienceRouter.js
@@ -5,7 +5,7 @@ const _ = require('lodash');
 router.get('/', (req, res) => {
   const { query, graphApi } = req;
   const { identity } = query;
-  graphApi.getContractorExpirience(identity)
+  graphApi.getContractorExperience(identity)
     .then(result => {
       res.send(result);
     })

--- a/server/routers/contractorRouter.js
+++ b/server/routers/contractorRouter.js
@@ -4,6 +4,7 @@ const _ = require('lodash');
 const contractorSkillsRouter = require('./contractorSkillsRouter');
 const contractorCertificaitonsRouter = require('./contractorCertificationsRouter');
 const contractorExperienceRouter = require('./contractorExperienceRouter');
+const contractorTeamRouter = require('./contractorTeamRouter');
 const jwtCheck = require('./../auth/auth').jwtCheck;
 
 
@@ -56,6 +57,6 @@ router.post('/update', (req, res) => {
 router.use('/skills', contractorSkillsRouter);
 router.use('/certifications', contractorCertificaitonsRouter);
 router.use('/experience', contractorExperienceRouter);
-
+router.use('/team', contractorTeamRouter);
 
 module.exports = router

--- a/server/routers/contractorTeamRouter.js
+++ b/server/routers/contractorTeamRouter.js
@@ -1,0 +1,30 @@
+const express = require('express');
+const router = express.Router();
+
+router.put('/add', (req, res) => {
+  const { body } = req;
+  req.graphApi.addContractorToTeam(body)
+  .then(result => {
+    res.send(result);
+  })
+  .catch(err => {
+    console.error(err);
+    res.send(err);
+  })
+})
+
+router.put('/remove', (req, res) => {
+  const { body } = req;
+  req.graphApi.removeContractorFromTeam(body)
+  .then(result => {
+    res.send(result);
+  })
+  .catch(err => {
+    console.error(err);
+    res.send(err);
+  })
+})
+
+
+
+module.exports = router;

--- a/server/routers/routersIndex.js
+++ b/server/routers/routersIndex.js
@@ -1,5 +1,6 @@
 const contractorRouter = require('./contractorRouter');
 const contractorSkillsRouter = require('./contractorSkillsRouter');
+const contractorTeamRouter = require('./contractorTeamRouter');
 const skillRouter = require('./skillRouter');
 const certificationRouter = require('./certificationRouter');
 const teamRouter = require('./teamRouter');
@@ -7,6 +8,7 @@ const teamRouter = require('./teamRouter');
 module.exports = {
   contractorRouter,
   contractorSkillsRouter,
+  contractorTeamRouter,
   skillRouter,
   certificationRouter,
   teamRouter,

--- a/server/routers/routersIndex.js
+++ b/server/routers/routersIndex.js
@@ -2,10 +2,12 @@ const contractorRouter = require('./contractorRouter');
 const contractorSkillsRouter = require('./contractorSkillsRouter');
 const skillRouter = require('./skillRouter');
 const certificationRouter = require('./certificationRouter');
+const teamRouter = require('./teamRouter');
 
 module.exports = {
   contractorRouter,
   contractorSkillsRouter,
   skillRouter,
   certificationRouter,
+  teamRouter,
 }

--- a/server/routers/teamRouter.js
+++ b/server/routers/teamRouter.js
@@ -1,0 +1,46 @@
+const express = require('express');
+const router = express.Router();
+const _ = require('lodash');
+
+
+// router.get('/', (req, res) => {
+//   if (!req.query) {
+//     res.send({ error: "no email given"});
+//     return;
+//   }
+//   req.graphApi.getContractorByEmail(req.query)
+//     .then(result => {
+//       console.log(result);
+//       res.send(result);
+//     })
+//     .catch(result => {
+//       res.send({error: "no Contractor found"});
+//     })
+// });
+
+router.post('/', (req, res) => {
+  const { body, query } = req;
+
+  req.graphApi.createTeam()
+    .then(result => {
+      res.send(result);
+    })
+    .catch(err => {
+      res.send(err)
+    });
+});
+
+// router.post('/update', (req, res) => {
+//   const { body } = req;
+//   req.graphApi.updateContractor(body)
+//     .then(result => {
+//       res.send(result)
+//     })
+//     .catch(err => {
+//       console.log('error when attempting to update contractor')
+//       console.log(err);
+//       res.send(err);
+//     })
+// })
+
+module.exports = router

--- a/server/routers/teamRouter.js
+++ b/server/routers/teamRouter.js
@@ -4,24 +4,13 @@ const _ = require('lodash');
 
 
 // router.get('/', (req, res) => {
-//   if (!req.query) {
-//     res.send({ error: "no email given"});
-//     return;
-//   }
-//   req.graphApi.getContractorByEmail(req.query)
-//     .then(result => {
-//       console.log(result);
-//       res.send(result);
-//     })
-//     .catch(result => {
-//       res.send({error: "no Contractor found"});
-//     })
+//
 // });
 
 router.post('/', (req, res) => {
   const { body, query } = req;
 
-  req.graphApi.createTeam()
+  req.graphApi.createTeam(body)
     .then(result => {
       res.send(result);
     })
@@ -31,16 +20,7 @@ router.post('/', (req, res) => {
 });
 
 // router.post('/update', (req, res) => {
-//   const { body } = req;
-//   req.graphApi.updateContractor(body)
-//     .then(result => {
-//       res.send(result)
-//     })
-//     .catch(err => {
-//       console.log('error when attempting to update contractor')
-//       console.log(err);
-//       res.send(err);
-//     })
+//
 // })
 
 module.exports = router

--- a/server/server.js
+++ b/server/server.js
@@ -18,6 +18,7 @@ const {
   contractorRouter,
   skillRouter,
   certificationRouter,
+  teamRouter,
 } = require('./routers/routersIndex');
 
 var app = express();
@@ -54,6 +55,7 @@ app.get('/api/unprotected', function(req, res) {
 app.use('/api/contractor', contractorRouter);
 app.use('/api/skill', skillRouter);
 app.use('/api/certification', certificationRouter);
+app.use('/api/team', teamRouter);
 
 app.listen(port);
 


### PR DESCRIPTION
Resolve #80 
This PR creates the API method for creating teams. POST requests should be made to /api/team. The request body should contain a teamName, an existing projectId and an existing locationId.
http://recordit.co/yaAHkkbM3R

EDIT:
Now also resolves #82 
This addition creates the ability to add or remove a contractor from a team.
PUT requests should be made to /api/contractor/team/add  or  /api/contractor/team/remove (depending on what you want to do.
Request body should contain an existing contractorId and an existing teamId.
http://recordit.co/J1QapQqqvo