### PR TITLE
TeamManager changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,4 @@ COPY . /wwwroot
 
 EXPOSE 3000 4000
 
-CMD ["npm", "run", "start"]
+CMD ["npm", "run", "dev-start"]

--- a/client/src/components/TeamManagerWrapper.js
+++ b/client/src/components/TeamManagerWrapper.js
@@ -8,9 +8,9 @@ import PropTypes from 'prop-types'
 function TeamManagerWrapper({ children, openAddTeamBox }) {
   return (
     <div>
-      <Button 
-        fab mini 
-        aria-label="add" 
+      <Button
+        fab mini
+        aria-label="add"
         className='fr'
         onClick={openAddTeamBox}
       >
@@ -25,7 +25,10 @@ function TeamManagerWrapper({ children, openAddTeamBox }) {
 
 TeamManagerWrapper.propTypes = {
   openAddTeamBox: PropTypes.func.isRequired,
-  children: PropTypes.element,
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node
+  ]).isRequired
 }
 
 export default TeamManagerWrapper

--- a/client/src/components/TeamSummaryBox.js
+++ b/client/src/components/TeamSummaryBox.js
@@ -52,13 +52,15 @@ const styles = {
 
 function TeamSummaryBox (props) {
   const testAction = () => console.log('testAction fired');
+  // TODO: Fix all this.
+  const teamName = props.team.properties ? props.team.properties.name : '';
 
   return (
     <div className={props.classes.wrapper}>
       <Paper
         className={props.classes.leftBar}
       >
-        left bar
+        {teamName}
       </Paper>
 
       <Paper
@@ -71,8 +73,8 @@ function TeamSummaryBox (props) {
             value={false}
             action={testAction}
           >
-            <Tab className={props.classes.tab} label="Item One" />
-            <Tab className={props.classes.tab} label="Item Two" />
+            <Tab className={props.classes.tab} label="Roles" />
+            <Tab className={props.classes.tab} label="Members" />
           </Tabs>
         </div>
         <Table>

--- a/client/src/components/TeamSummaryBox.js
+++ b/client/src/components/TeamSummaryBox.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import Grid from 'material-ui/Grid';
 import Paper from 'material-ui/Paper';
 import Tabs, { Tab } from 'material-ui/Tabs';
+import Typography from 'material-ui/Typography';
 
 import { withStyles } from 'material-ui/styles';
 import Table, { TableBody, TableCell, TableHead, TableRow } from 'material-ui/Table';
@@ -27,12 +28,20 @@ const styles = {
   wrapper: {
     display: 'flex',
     height: '70vh',
+    paddingTop: 16,
+  },
+  infoTitle: {
+    fontWeight: 'bold'
   },
   leftBar: {
+    padding: 16,
     backgroundColor: 'lightgrey',
     height: '100%',
     flex: '1 0 200px',
     margin: '0 10px 0 0',
+  },
+  leftBarSection: {
+    marginTop: '20px',
   },
   main: {
     display: 'flex',
@@ -52,20 +61,44 @@ const styles = {
 
 function TeamSummaryBox (props) {
   const testAction = () => console.log('testAction fired');
+
   // TODO: Fix all this.
   const teamName = props.team.properties ? props.team.properties.name : '';
+  const locationName = props.location.properties ? props.location.properties.name : '';
+  const projectName = props.project.properties ? props.project.properties.name : '';
+  const startDate = props.team.properties ? props.team.properties.startDate : '';
+  const endDate = props.team.properties ? props.team.properties.endDate : '';
 
   return (
     <div className={props.classes.wrapper}>
-      <Paper
-        className={props.classes.leftBar}
-      >
-        {teamName}
+      <Paper className={props.classes.leftBar}>
+        <Typography type='title'>
+          {teamName}
+        </Typography>
+
+        <section className={props.classes.leftBarSection}>
+          <Typography component='p' className={props.classes.infoTitle}>Project:</Typography>
+          <Typography component='p'>{projectName}</Typography>
+        </section>
+
+        <section className={props.classes.leftBarSection}>
+          <Typography component='p' className={props.classes.infoTitle}>Location:</Typography>
+          <Typography component='p'>{locationName}</Typography>
+        </section>
+
+        <section className={props.classes.leftBarSection}>
+          <Typography component='p' className={props.classes.infoTitle}>Start Date:</Typography>
+          <Typography component='p'>{startDate}</Typography>
+        </section>
+
+        <section className={props.classes.leftBarSection}>
+          <Typography component='p' className={props.classes.infoTitle}>End Date:</Typography>
+          <Typography component='p'>{endDate}</Typography>
+        </section>
+
       </Paper>
 
-      <Paper
-        className={props.classes.main}
-      >
+      <Paper className={props.classes.main}>
         <div className={props.classes.buttonSection}>
           <Tabs
             indicatorColor="primary"
@@ -77,6 +110,7 @@ function TeamSummaryBox (props) {
             <Tab className={props.classes.tab} label="Members" />
           </Tabs>
         </div>
+
         <Table>
           <TableHead>
             <TableRow>

--- a/client/src/components/TeamSummaryBox.js
+++ b/client/src/components/TeamSummaryBox.js
@@ -1,0 +1,116 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import Grid from 'material-ui/Grid';
+import Paper from 'material-ui/Paper';
+import Tabs, { Tab } from 'material-ui/Tabs';
+
+import { withStyles } from 'material-ui/styles';
+import Table, { TableBody, TableCell, TableHead, TableRow } from 'material-ui/Table';
+
+
+//DUMMY DATA
+let id = 0;
+function createData(type, skillLevel, weekDays, time, requested, filled) {
+  id += 1;
+  return { id, type, skillLevel, weekDays, time, requested, filled };
+}
+const data = [
+  createData('Electrician', 1, 'M, Tu, W', '9am - 5pm', '2', '2'),
+  createData('Electrician', 2, 'M, Tu, W', '9am - 5pm', '2', '2'),
+  createData('Welder', 1, 'M, Tu, W, Th, F', '9am - 5pm', '1', '0'),
+  createData('Magician', 1, 'M, Tu, W', '9am - 5pm', '2', '0'),
+  createData('Pipe Fitter', 2, 'W, Th, F', '9am - 5pm', '2', '1'),
+];
+//END DUMMY DATA
+
+const styles = {
+  wrapper: {
+    display: 'flex',
+    height: '70vh',
+  },
+  leftBar: {
+    backgroundColor: 'lightgrey',
+    height: '100%',
+    flex: '1 0 200px',
+    margin: '0 10px 0 0',
+  },
+  main: {
+    display: 'flex',
+    flexDirection: 'column',
+    height: '100%',
+    flex: '2 0 auto',
+    margin: '0 0 0 10px',
+  },
+  buttonSection: {
+    flexBasis: '50px',
+    marginBottom: '10px',
+  },
+  tab: {
+    minWidth: '120px',
+  },
+};
+
+function TeamSummaryBox (props) {
+  const testAction = () => console.log('testAction fired');
+
+  return (
+    <div className={props.classes.wrapper}>
+      <Paper
+        className={props.classes.leftBar}
+      >
+        left bar
+      </Paper>
+
+      <Paper
+        className={props.classes.main}
+      >
+        <div className={props.classes.buttonSection}>
+          <Tabs
+            indicatorColor="primary"
+            textColor="primary"
+            value={false}
+            action={testAction}
+          >
+            <Tab className={props.classes.tab} label="Item One" />
+            <Tab className={props.classes.tab} label="Item Two" />
+          </Tabs>
+        </div>
+        <Table>
+          <TableHead>
+            <TableRow>
+              <TableCell>Type</TableCell>
+              <TableCell>Skill level</TableCell>
+              <TableCell>Week Days</TableCell>
+              <TableCell>Time</TableCell>
+              <TableCell>Requested</TableCell>
+              <TableCell>Filled</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {data.map(n => {
+              return (
+                <TableRow key={n.id}>
+                  <TableCell>{n.type} - {n.skillLevel}</TableCell>
+                  <TableCell>{n.skillLevel}</TableCell>
+                  <TableCell>{n.weekDays}</TableCell>
+                  <TableCell>{n.time}</TableCell>
+                  <TableCell>{n.requested}</TableCell>
+                  <TableCell>{n.filled}</TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      </Paper>
+    </div>
+  )
+}
+
+TeamSummaryBox.propTypes = {
+  classes: PropTypes.object.isRequired,
+//   name: PropTypes.string.isRequired,
+//   handleRequestDelete: PropTypes.func,
+//   identity: PropTypes.string,
+}
+
+export default withStyles(styles)(TeamSummaryBox);

--- a/client/src/components/componentIndex.js
+++ b/client/src/components/componentIndex.js
@@ -15,6 +15,8 @@ import SkillListItem from './SkillListItem';
 import ExperienceListItem from './ExperienceListItem';
 import AddExperienceBox from './AddExperienceBox';
 import TeamManagerWrapper from './TeamManagerWrapper';
+import TeamSummaryBox from './TeamSummaryBox';
+
 
 export {
   Autocomplete,
@@ -34,4 +36,5 @@ export {
   ExperienceListItem,
   AddExperienceBox,
   TeamManagerWrapper,
+  TeamSummaryBox,
 }

--- a/client/src/containers/Dashboard.js
+++ b/client/src/containers/Dashboard.js
@@ -54,7 +54,7 @@ class Dashboard extends Component {
             <Route path={`${match.path}/onBoardFlow`} component={OnBoardFlow}/>
             <Route path={`${match.path}/profile`} component={Profile}/>
             <Route exact path={`${match.path}/teamManager`} component={TeamManager} />
-            <Route path={`${match.path}/teamManager/:team`} component={TeamDetails} />
+            <Route path={`${match.path}/teamManager/:teamId`} component={TeamDetails} />
             <Route exact path={`${match.path}`} render={() => (<Redirect to={`${match.path}/profile`}/>)}/>
           </div>
         </div>

--- a/client/src/containers/Dashboard.js
+++ b/client/src/containers/Dashboard.js
@@ -23,6 +23,7 @@ import {
   OnBoardFlow,
   Profile,
   SideNavBar,
+  TeamDetails,
   TeamManager,
 } from './containerIndex'
 
@@ -45,14 +46,15 @@ class Dashboard extends Component {
     return user ? (
         <div>
           <div className='fl w-20 pa2'>
-            <SideNavBar 
+            <SideNavBar
               history={history}
             />
           </div>
           <div className='fl w-80 pa2'>
             <Route path={`${match.path}/onBoardFlow`} component={OnBoardFlow}/>
             <Route path={`${match.path}/profile`} component={Profile}/>
-            <Route path={`${match.path}/teamManager`} component={TeamManager} />
+            <Route exact path={`${match.path}/teamManager`} component={TeamManager} />
+            <Route path={`${match.path}/teamManager/:team`} component={TeamDetails} />
             <Route exact path={`${match.path}`} render={() => (<Redirect to={`${match.path}/profile`}/>)}/>
           </div>
         </div>

--- a/client/src/containers/TeamDetails.js
+++ b/client/src/containers/TeamDetails.js
@@ -1,12 +1,10 @@
 import React, { Component } from 'react';
-
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import { withRouter } from 'react-router'
 
 //Actions
 import * as actionCreators from '../redux/actions/actionCreators';
-
-// import {
-//
-// } from './containerIndex';
 
 import {
   TeamSummaryBox,
@@ -17,18 +15,32 @@ class TeamDetails extends Component {
     super(props);
 
     this.state = {
-      // AddTeamBoxOpen: false,
+      teamId: this.props.match.params.teamId,
     }
 
+  }
+
+  componentWillMount() {
+    this.props.getTeam(this.state.teamId);
   }
 
   render() {
     return (
       <div>
-        <TeamSummaryBox />
+        <TeamSummaryBox
+          team={this.props.teams.team}
+        />
       </div>
     )
   }
 }
 
-export default TeamDetails
+
+function mapStateToProps({projects, teams}) {
+  return {projects, teams}
+}
+
+function mapDispatchToProps(dispatch) {
+  return bindActionCreators(actionCreators, dispatch)
+}
+export default withRouter(connect(mapStateToProps, mapDispatchToProps)(TeamDetails))

--- a/client/src/containers/TeamDetails.js
+++ b/client/src/containers/TeamDetails.js
@@ -29,6 +29,8 @@ class TeamDetails extends Component {
       <div>
         <TeamSummaryBox
           team={this.props.teams.team}
+          location={this.props.teams.location}
+          project={this.props.teams.project}
         />
       </div>
     )

--- a/client/src/containers/TeamDetails.js
+++ b/client/src/containers/TeamDetails.js
@@ -1,0 +1,34 @@
+import React, { Component } from 'react';
+
+
+//Actions
+import * as actionCreators from '../redux/actions/actionCreators';
+
+// import {
+//
+// } from './containerIndex';
+
+import {
+  TeamSummaryBox,
+} from './../components/componentIndex';
+
+class TeamDetails extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      // AddTeamBoxOpen: false,
+    }
+
+  }
+
+  render() {
+    return (
+      <div>
+        <TeamSummaryBox />
+      </div>
+    )
+  }
+}
+
+export default TeamDetails

--- a/client/src/containers/TeamManager.js
+++ b/client/src/containers/TeamManager.js
@@ -53,11 +53,13 @@ class TeamManager extends Component {
           projects={this.props.projects.allProjects}
         />
         <ul>
-          {/* {this.props.teams.allTeams.map((team, idx) => <li key={idx}>{team.properties.name}</li>)} */}
-          {this.props.teams.allTeams.map((team, idx) => {
-            console.log(team);
-            return (<li><Link to={`/dashboard/teamManager/${team.identity}`} key={idx}>{team.properties.name}</Link></li>)  
-          })}
+          {
+            this.props.teams.allTeams.map((team, idx) =>
+              <li key={idx}>
+                <Link to={`/dashboard/teamManager/${team.identity}`}>{team.properties.name}</Link>
+              </li>
+            )
+          }
         </ul>
       </TeamManagerWrapper>
     )

--- a/client/src/containers/TeamManager.js
+++ b/client/src/containers/TeamManager.js
@@ -27,6 +27,10 @@ class TeamManager extends Component {
     this.handleAddTeam = this.handleAddTeam.bind(this)
   }
 
+  componentWillMount() {
+    this.props.getAllTeams()
+  }
+
   toggleAddTeamBox() {
     this.setState({AddTeamBoxOpen: !this.state.AddTeamBoxOpen})
   }
@@ -47,6 +51,9 @@ class TeamManager extends Component {
           handleAddTeam={this.handleAddTeam}
           projects={this.props.projects.allProjects}
         />
+        <ul>
+          {this.props.teams.allTeams.map((team, idx) => <li key={idx}>{team.properties.name}</li>)}
+        </ul>
       </TeamManagerWrapper>
     )
   }

--- a/client/src/containers/TeamManager.js
+++ b/client/src/containers/TeamManager.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { withRouter } from 'react-router'
+import { Link } from 'react-router-dom'
 
 //Actions
 import * as actionCreators from '../redux/actions/actionCreators';
@@ -52,7 +53,11 @@ class TeamManager extends Component {
           projects={this.props.projects.allProjects}
         />
         <ul>
-          {this.props.teams.allTeams.map((team, idx) => <li key={idx}>{team.properties.name}</li>)}
+          {/* {this.props.teams.allTeams.map((team, idx) => <li key={idx}>{team.properties.name}</li>)} */}
+          {this.props.teams.allTeams.map((team, idx) => {
+            console.log(team);
+            return (<li><Link to={`/dashboard/teamManager/${team.identity}`} key={idx}>{team.properties.name}</Link></li>)  
+          })}
         </ul>
       </TeamManagerWrapper>
     )

--- a/client/src/containers/containerIndex.js
+++ b/client/src/containers/containerIndex.js
@@ -8,6 +8,7 @@ import ProfileSkillCard from './ProfileSkillCard';
 import ProfileCertificationsCard from './ProfileCertificationsCard';
 import ProfileExperienceCard from './ProfileExperienceCard';
 import SideNavBar from './SideNavBar';
+import TeamDetails from './TeamDetails';
 import TeamManager from './TeamManager';
 import WeekDayPicker from './WeekDayPicker';
 
@@ -22,6 +23,7 @@ export {
   ProfileCertificationsCard,
   ProfileExperienceCard,
   SideNavBar,
+  TeamDetails,
   TeamManager,
   WeekDayPicker,
 }

--- a/client/src/redux/actions/actionCreators.js
+++ b/client/src/redux/actions/actionCreators.js
@@ -174,6 +174,13 @@ export function getTeam(id) {
   }
 }
 
+export function getTeamFulfilled(payload) {
+  return {
+    type: types.GET_TEAM_FULFILLED,
+    payload: payload
+  }
+}
+
 export function getAllTeams() {
   return {
     type: types.GET_ALL_TEAMS,
@@ -181,12 +188,13 @@ export function getAllTeams() {
   }
 }
 
-export function getTeamFulfilled(payload) {
+export function getAllTeamsFulfilled(payload) {
   return {
-    type: types.GET_TEAM_FULFILLED,
+    type: types.GET_ALL_TEAMS_FULFILLED,
     payload: payload
   }
 }
+
 
 export function getProject(id) {
   return {

--- a/client/src/redux/actions/actionCreators.js
+++ b/client/src/redux/actions/actionCreators.js
@@ -211,8 +211,6 @@ export function getAllProjects() {
 }
 
 export function getProjectFulfilled(payload) {
-  console.log('payload in getProjectFulfilled')
-  console.log(payload);
   return {
     type: types.GET_PROJECT_FULFILLED,
     payload: payload

--- a/client/src/redux/modules/team.js
+++ b/client/src/redux/modules/team.js
@@ -45,7 +45,7 @@ const getTeamEpic = (action$, state) => {
       action => {
         return ajax.getJSON(`http://${DOMAIN}:4000/api/team?teamId=${action.payload}`)
           .map(response => {
-            return getTeamFulfilled(response[0]);
+            return getTeamFulfilled(response);
           })
       }
     )
@@ -55,13 +55,20 @@ const getTeamEpic = (action$, state) => {
 const teams = (state = {
   allTeams: [],
   team: {},
+  location: {},
+  project: {},
 }, action) => {
   const { type, payload } = action;
   switch (type) {
     case GET_ALL_TEAMS_FULFILLED:
       return { ...state, allTeams: payload || [] };
     case GET_TEAM_FULFILLED:
-      return { ...state, team: payload || {} }
+      return {
+        ...state,
+        team: payload[0] || {},
+        location: payload[1] || {},
+        project: payload[2] || {},
+      }
     default:
       return state;
   }

--- a/client/src/redux/modules/team.js
+++ b/client/src/redux/modules/team.js
@@ -1,10 +1,11 @@
 import { ajax } from 'rxjs/observable/dom/ajax';
 import { Observable } from 'rxjs'
-import { getTeamFulfilled } from './../actions/actionCreators';
+import { getTeamFulfilled, getAllTeamsFulfilled } from './../actions/actionCreators';
 import {
   ADD_TEAM,
   GET_TEAM,
   GET_ALL_TEAMS,
+  GET_ALL_TEAMS_FULFILLED,
   GET_TEAM_FULFILLED,
 } from '../../utils/types';
 
@@ -30,11 +31,11 @@ const getAllTeamsEpic = (action$, state) => {
       action => {
         return ajax.getJSON(`http://${DOMAIN}:4000/api/team`)
           .map(response => {
-            return getTeamFulfilled(response);
+            return getAllTeamsFulfilled(response);
           })
       }
     )
-    .concat(action$.mapTo({ type: GET_TEAM_FULFILLED }))
+    .concat(action$.mapTo({ type: GET_ALL_TEAMS_FULFILLED }))
 }
 
 const getTeamEpic = (action$, state) => {
@@ -56,8 +57,14 @@ const teams = (state = {
 }, action) => {
   const { type, payload } = action;
   switch (type) {
-    case GET_TEAM_FULFILLED:
+    case GET_ALL_TEAMS_FULFILLED:
+      console.log('payload from GET_ALL_TEAMS_FULFILLED');
+      console.log(payload);
       return {...state, allTeams: payload || []};
+    case GET_TEAM_FULFILLED:
+      console.log('payload from GET_TEAM_FULFILLED');
+      console.log(payload);
+      return {...state, deleteThisProperty: []}
     default:
       return state;
   }

--- a/client/src/redux/modules/team.js
+++ b/client/src/redux/modules/team.js
@@ -45,7 +45,7 @@ const getTeamEpic = (action$, state) => {
       action => {
         return ajax.getJSON(`http://${DOMAIN}:4000/api/team?teamId=${action.payload}`)
           .map(response => {
-            return getTeamFulfilled(response);
+            return getTeamFulfilled(response[0]);
           })
       }
     )
@@ -54,17 +54,14 @@ const getTeamEpic = (action$, state) => {
 
 const teams = (state = {
   allTeams: [],
+  team: {},
 }, action) => {
   const { type, payload } = action;
   switch (type) {
     case GET_ALL_TEAMS_FULFILLED:
-      console.log('payload from GET_ALL_TEAMS_FULFILLED');
-      console.log(payload);
-      return {...state, allTeams: payload || []};
+      return { ...state, allTeams: payload || [] };
     case GET_TEAM_FULFILLED:
-      console.log('payload from GET_TEAM_FULFILLED');
-      console.log(payload);
-      return {...state, deleteThisProperty: []}
+      return { ...state, team: payload || {} }
     default:
       return state;
   }

--- a/client/src/utils/types.js
+++ b/client/src/utils/types.js
@@ -32,6 +32,7 @@ export const ADD_TEAM = 'ADD_TEAM';
 export const GET_TEAM = 'GET_TEAM';
 export const GET_ALL_TEAMS = 'GET_ALL_TEAMS';
 export const GET_TEAM_FULFILLED = 'GET_TEAM_FULFILLED';
+export const GET_ALL_TEAMS_FULFILLED = 'GET_ALL_TEAMS_FULFILLED';
 
 
 export const GET_PROJECT = 'GET_PROJECT';

--- a/server/database/graphApi.js
+++ b/server/database/graphApi.js
@@ -269,7 +269,7 @@ class GraphApi {
     const session = this.driver.session();
     return session
       .run(`
-        MATCH (t:Team) WHERE id(t) = 41
+        MATCH (t:Team) WHERE id(t) = ${teamId}
         OPTIONAL MATCH (p:Project)-[]-(t)
         OPTIONAL MATCH (l:Location)-[]-(p)
         RETURN t,l,p

--- a/server/database/graphApi.js
+++ b/server/database/graphApi.js
@@ -269,8 +269,10 @@ class GraphApi {
     const session = this.driver.session();
     return session
       .run(`
-        MATCH (t:Team) WHERE ID(t) = ${teamId}
-        RETURN t
+        MATCH (t:Team) WHERE id(t) = 41
+        OPTIONAL MATCH (p:Project)-[]-(t)
+        OPTIONAL MATCH (l:Location)-[]-(p)
+        RETURN t,l,p
       `)
       .then(result => {
         const { records } = result;


### PR DESCRIPTION
This PR adds the ability to create a team and add it to a project, give it start and end dates.
This PR also adds some changes to the API methods for teams: getTeam now returns not only the team node, but project node connected to the team, and in turn the location node connected to the project. These details are rendered in the TeamSummaryBox component.
(There are still a couple of minor bugs, but thought I'd get this PR through before it gets too big.)

Partly resolves #73 