### PR TITLE
Changes to Team Summary Table

### DIFF
--- a/client/src/components/TeamSummaryBox.js
+++ b/client/src/components/TeamSummaryBox.js
@@ -1,35 +1,9 @@
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
-import Grid from 'material-ui/Grid';
+import React from 'react';
 import Paper from 'material-ui/Paper';
-import Tabs, { Tab } from 'material-ui/Tabs';
 import Typography from 'material-ui/Typography';
-
 import { withStyles } from 'material-ui/styles';
-import Table, { TableBody, TableCell, TableHead, TableRow } from 'material-ui/Table';
-
-
-//DUMMY DATA
-let id = 0;
-function createData(type, skillLevel, weekDays, time, requested, filled) {
-  id += 1;
-  return { id, type, skillLevel, weekDays, time, requested, filled };
-}
-const data = [
-  createData('Electrician', 1, 'M, Tu, W', '9am - 5pm', '2', '2'),
-  createData('Electrician', 2, 'M, Tu, W', '9am - 5pm', '2', '2'),
-  createData('Welder', 1, 'M, Tu, W, Th, F', '9am - 5pm', '1', '0'),
-  createData('Magician', 1, 'M, Tu, W', '9am - 5pm', '2', '0'),
-  createData('Pipe Fitter', 2, 'W, Th, F', '9am - 5pm', '2', '1'),
-];
-//END DUMMY DATA
 
 const styles = {
-  wrapper: {
-    display: 'flex',
-    height: '70vh',
-    paddingTop: 16,
-  },
   infoTitle: {
     fontWeight: 'bold'
   },
@@ -43,25 +17,9 @@ const styles = {
   leftBarSection: {
     marginTop: '20px',
   },
-  main: {
-    display: 'flex',
-    flexDirection: 'column',
-    height: '100%',
-    flex: '2 0 auto',
-    margin: '0 0 0 10px',
-  },
-  buttonSection: {
-    flexBasis: '50px',
-    marginBottom: '10px',
-  },
-  tab: {
-    minWidth: '120px',
-  },
 };
 
 function TeamSummaryBox (props) {
-  const testAction = () => console.log('testAction fired');
-
   // TODO: Fix all this.
   const teamName = props.team.properties ? props.team.properties.name : '';
   const locationName = props.location.properties ? props.location.properties.name : '';
@@ -70,83 +28,33 @@ function TeamSummaryBox (props) {
   const endDate = props.team.properties ? props.team.properties.endDate : '';
 
   return (
-    <div className={props.classes.wrapper}>
-      <Paper className={props.classes.leftBar}>
-        <Typography type='title'>
-          {teamName}
-        </Typography>
+    <Paper className={props.classes.leftBar}>
+      <Typography type='title'>
+        {teamName}
+      </Typography>
 
-        <section className={props.classes.leftBarSection}>
-          <Typography component='p' className={props.classes.infoTitle}>Project:</Typography>
-          <Typography component='p'>{projectName}</Typography>
-        </section>
+      <section className={props.classes.leftBarSection}>
+        <Typography component='p' className={props.classes.infoTitle}>Project:</Typography>
+        <Typography component='p'>{projectName}</Typography>
+      </section>
 
-        <section className={props.classes.leftBarSection}>
-          <Typography component='p' className={props.classes.infoTitle}>Location:</Typography>
-          <Typography component='p'>{locationName}</Typography>
-        </section>
+      <section className={props.classes.leftBarSection}>
+        <Typography component='p' className={props.classes.infoTitle}>Location:</Typography>
+        <Typography component='p'>{locationName}</Typography>
+      </section>
 
-        <section className={props.classes.leftBarSection}>
-          <Typography component='p' className={props.classes.infoTitle}>Start Date:</Typography>
-          <Typography component='p'>{startDate}</Typography>
-        </section>
+      <section className={props.classes.leftBarSection}>
+        <Typography component='p' className={props.classes.infoTitle}>Start Date:</Typography>
+        <Typography component='p'>{startDate}</Typography>
+      </section>
 
-        <section className={props.classes.leftBarSection}>
-          <Typography component='p' className={props.classes.infoTitle}>End Date:</Typography>
-          <Typography component='p'>{endDate}</Typography>
-        </section>
+      <section className={props.classes.leftBarSection}>
+        <Typography component='p' className={props.classes.infoTitle}>End Date:</Typography>
+        <Typography component='p'>{endDate}</Typography>
+      </section>
 
-      </Paper>
-
-      <Paper className={props.classes.main}>
-        <div className={props.classes.buttonSection}>
-          <Tabs
-            indicatorColor="primary"
-            textColor="primary"
-            value={false}
-            action={testAction}
-          >
-            <Tab className={props.classes.tab} label="Roles" />
-            <Tab className={props.classes.tab} label="Members" />
-          </Tabs>
-        </div>
-
-        <Table>
-          <TableHead>
-            <TableRow>
-              <TableCell>Type</TableCell>
-              <TableCell>Skill level</TableCell>
-              <TableCell>Week Days</TableCell>
-              <TableCell>Time</TableCell>
-              <TableCell>Requested</TableCell>
-              <TableCell>Filled</TableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {data.map(n => {
-              return (
-                <TableRow key={n.id}>
-                  <TableCell>{n.type} - {n.skillLevel}</TableCell>
-                  <TableCell>{n.skillLevel}</TableCell>
-                  <TableCell>{n.weekDays}</TableCell>
-                  <TableCell>{n.time}</TableCell>
-                  <TableCell>{n.requested}</TableCell>
-                  <TableCell>{n.filled}</TableCell>
-                </TableRow>
-              );
-            })}
-          </TableBody>
-        </Table>
-      </Paper>
-    </div>
+    </Paper>
   )
-}
-
-TeamSummaryBox.propTypes = {
-  classes: PropTypes.object.isRequired,
-//   name: PropTypes.string.isRequired,
-//   handleRequestDelete: PropTypes.func,
-//   identity: PropTypes.string,
 }
 
 export default withStyles(styles)(TeamSummaryBox);

--- a/client/src/components/TeamSummaryMembers.js
+++ b/client/src/components/TeamSummaryMembers.js
@@ -8,16 +8,16 @@ import Table, { TableBody, TableCell, TableHead, TableRow } from 'material-ui/Ta
 
 //DUMMY DATA
 let id = 0;
-function createData(type, skillLevel, weekDays, time, requested, filled) {
+function createData(name, type, skillLevel, rate, status) {
   id += 1;
-  return { id, type, skillLevel, weekDays, time, requested, filled };
+  return { id, name, type, skillLevel, rate, status };
 }
 const data = [
-  createData('Electrician', 1, 'M, Tu, W', '9am - 5pm', '2', '2'),
-  createData('Electrician', 2, 'M, Tu, W', '9am - 5pm', '2', '2'),
-  createData('Welder', 1, 'M, Tu, W, Th, F', '9am - 5pm', '1', '0'),
-  createData('Magician', 1, 'M, Tu, W', '9am - 5pm', '2', '0'),
-  createData('Pipe Fitter', 2, 'W, Th, F', '9am - 5pm', '2', '1'),
+  createData('Joe Schmo', 'Electrician', 1, 22, 1),
+  createData('Derek Zoolander', 'Electrician', 2, 20, 1),
+  createData('Jack Johnson', 'Welder', 1, 18, 0),
+  createData('Stevie Nicks', 'Magician', 1, 24, 0),
+  createData('James Franco', 'Pipe Fitter', 2, 21, 1),
 ];
 //END DUMMY DATA
 
@@ -44,17 +44,23 @@ function TeamSummaryMembers (props) {
       <TableHead>
         <TableRow>
           <TableCell>Name</TableCell>
-          <TableCell>Position</TableCell>
-          <TableCell>Position Level</TableCell>
+          <TableCell>Role</TableCell>
+          <TableCell>Type</TableCell>
+          <TableCell>Skill Level</TableCell>
+          <TableCell>Rate ($)</TableCell>
+          <TableCell>Status</TableCell>
         </TableRow>
       </TableHead>
       <TableBody>
-        {data.map(n => {
+        {data.map((member) => {
           return (
-            <TableRow key={n.id}>
-              <TableCell>John Smith</TableCell>
-              <TableCell>{n.type}</TableCell>
-              <TableCell>{n.skillLevel}</TableCell>
+            <TableRow key={member.id}>
+              <TableCell>{member.name}</TableCell>
+              <TableCell>{member.type} - {member.skillLevel}</TableCell>
+              <TableCell>{member.type}</TableCell>
+              <TableCell>Class {member.skillLevel}</TableCell>
+              <TableCell>${member.rate}/hr</TableCell>
+              <TableCell>{member.status === 1 ? 'Confirmed' : 'Pending'}</TableCell>
             </TableRow>
           );
         })}

--- a/client/src/components/TeamSummaryMembers.js
+++ b/client/src/components/TeamSummaryMembers.js
@@ -1,0 +1,73 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import Paper from 'material-ui/Paper';
+import Tabs, { Tab } from 'material-ui/Tabs';
+
+import { withStyles } from 'material-ui/styles';
+import Table, { TableBody, TableCell, TableHead, TableRow } from 'material-ui/Table';
+
+//DUMMY DATA
+let id = 0;
+function createData(type, skillLevel, weekDays, time, requested, filled) {
+  id += 1;
+  return { id, type, skillLevel, weekDays, time, requested, filled };
+}
+const data = [
+  createData('Electrician', 1, 'M, Tu, W', '9am - 5pm', '2', '2'),
+  createData('Electrician', 2, 'M, Tu, W', '9am - 5pm', '2', '2'),
+  createData('Welder', 1, 'M, Tu, W, Th, F', '9am - 5pm', '1', '0'),
+  createData('Magician', 1, 'M, Tu, W', '9am - 5pm', '2', '0'),
+  createData('Pipe Fitter', 2, 'W, Th, F', '9am - 5pm', '2', '1'),
+];
+//END DUMMY DATA
+
+const styles = {
+  main: {
+    display: 'flex',
+    flexDirection: 'column',
+    height: '100%',
+    flex: '2 0 auto',
+    margin: '0 0 0 10px',
+  },
+  buttonSection: {
+    flexBasis: '50px',
+    marginBottom: '10px',
+  },
+  tab: {
+    minWidth: '120px',
+  },
+};
+
+function TeamSummaryMembers (props) {
+  return (
+    <Table>
+      <TableHead>
+        <TableRow>
+          <TableCell>Name</TableCell>
+          <TableCell>Position</TableCell>
+          <TableCell>Position Level</TableCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {data.map(n => {
+          return (
+            <TableRow key={n.id}>
+              <TableCell>John Smith</TableCell>
+              <TableCell>{n.type}</TableCell>
+              <TableCell>{n.skillLevel}</TableCell>
+            </TableRow>
+          );
+        })}
+      </TableBody>
+    </Table>
+  )
+};
+
+TeamSummaryMembers.propTypes = {
+  classes: PropTypes.object.isRequired,
+//   name: PropTypes.string.isRequired,
+//   handleRequestDelete: PropTypes.func,
+//   identity: PropTypes.string,
+}
+
+export default withStyles(styles)(TeamSummaryMembers);

--- a/client/src/components/TeamSummaryRoles.js
+++ b/client/src/components/TeamSummaryRoles.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import Table, { TableBody, TableCell, TableHead, TableRow } from 'material-ui/Table';
+
+//DUMMY DATA
+let id = 0;
+function createData(type, skillLevel, weekDays, time, requested, filled) {
+  id += 1;
+  return { id, type, skillLevel, weekDays, time, requested, filled };
+}
+const data = [
+  createData('Electrician', 1, 'M, Tu, W', '9am - 5pm', '2', '2'),
+  createData('Electrician', 2, 'M, Tu, W', '9am - 5pm', '2', '2'),
+  createData('Welder', 1, 'M, Tu, W, Th, F', '9am - 5pm', '1', '0'),
+  createData('Magician', 1, 'M, Tu, W', '9am - 5pm', '2', '0'),
+  createData('Pipe Fitter', 2, 'W, Th, F', '9am - 5pm', '2', '1'),
+];
+//END DUMMY DATA
+
+function TeamSummaryRoles (props) {
+  return (
+    <Table>
+      <TableHead>
+        <TableRow>
+          <TableCell>Type</TableCell>
+          <TableCell>Skill level</TableCell>
+          <TableCell>Week Days</TableCell>
+          <TableCell>Time</TableCell>
+          <TableCell>Requested</TableCell>
+          <TableCell>Filled</TableCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {data.map(n => {
+          return (
+            <TableRow key={n.id}>
+              <TableCell>{n.type} - {n.skillLevel}</TableCell>
+              <TableCell>{n.skillLevel}</TableCell>
+              <TableCell>{n.weekDays}</TableCell>
+              <TableCell>{n.time}</TableCell>
+              <TableCell>{n.requested}</TableCell>
+              <TableCell>{n.filled}</TableCell>
+            </TableRow>
+          );
+        })}
+      </TableBody>
+    </Table>
+  )
+};
+
+export default TeamSummaryRoles;

--- a/client/src/components/TeamSummaryTable.js
+++ b/client/src/components/TeamSummaryTable.js
@@ -1,0 +1,70 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import Paper from 'material-ui/Paper';
+import Tabs, { Tab } from 'material-ui/Tabs';
+
+import {TeamSummaryRoles, TeamSummaryMembers} from './componentIndex';
+
+import { withStyles } from 'material-ui/styles';
+
+const styles = {
+  main: {
+    display: 'flex',
+    flexDirection: 'column',
+    height: '100%',
+    flex: '2 0 66%',
+    margin: '0 0 0 10px',
+  },
+  buttonSection: {
+    flexBasis: '50px',
+    marginBottom: '10px',
+  },
+  tab: {
+    minWidth: '120px',
+  },
+};
+
+class TeamSummaryTable extends React.Component {
+  constructor() {
+    super();
+    this.handleChange = this.handleChange.bind(this);
+
+    this.state = {
+      value: 0,
+    };
+  }
+
+  handleChange (event, value) {
+    this.setState({value});
+  }
+
+  render() {
+    const { value } = this.state;
+    return (
+      <Paper className={this.props.classes.main}>
+        <div className={this.props.classes.buttonSection}>
+          <Tabs
+            indicatorColor="primary"
+            textColor="primary"
+            value={this.state.value}
+            onChange={this.handleChange}
+          >
+            <Tab className={this.props.classes.tab} label="Roles" />
+            <Tab className={this.props.classes.tab} label="Members" />
+          </Tabs>
+        </div>
+        { value === 0 && <TeamSummaryRoles /> }
+        { value === 1 && <TeamSummaryMembers /> }
+      </Paper>
+    )
+  }
+};
+
+TeamSummaryTable.propTypes = {
+  classes: PropTypes.object.isRequired,
+//   name: PropTypes.string.isRequired,
+//   handleRequestDelete: PropTypes.func,
+//   identity: PropTypes.string,
+}
+
+export default withStyles(styles)(TeamSummaryTable);

--- a/client/src/components/TeamSummaryWrapper.js
+++ b/client/src/components/TeamSummaryWrapper.js
@@ -1,0 +1,45 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import Grid from 'material-ui/Grid';
+import Paper from 'material-ui/Paper';
+import Tabs, { Tab } from 'material-ui/Tabs';
+import Typography from 'material-ui/Typography';
+
+import { withStyles } from 'material-ui/styles';
+import Table, { TableBody, TableCell, TableHead, TableRow } from 'material-ui/Table';
+
+import { TeamSummaryBox, TeamSummaryTable } from './componentIndex';
+
+const styles = {
+  wrapper: {
+    display: 'flex',
+    height: '70vh',
+    paddingTop: 16,
+  },
+};
+
+function TeamSummaryWrapper (props) {
+  return (
+    <div className={props.classes.wrapper}>
+      <TeamSummaryBox
+        team={props.team}
+        location={props.location}
+        project={props.project}
+      />
+      <TeamSummaryTable
+        team={props.team}
+        location={props.location}
+        project={props.project}
+      />
+    </div>
+  )
+}
+
+TeamSummaryWrapper.propTypes = {
+  classes: PropTypes.object.isRequired,
+//   name: PropTypes.string.isRequired,
+//   handleRequestDelete: PropTypes.func,
+//   identity: PropTypes.string,
+}
+
+export default withStyles(styles)(TeamSummaryWrapper);

--- a/client/src/components/componentIndex.js
+++ b/client/src/components/componentIndex.js
@@ -16,6 +16,10 @@ import ExperienceListItem from './ExperienceListItem';
 import AddExperienceBox from './AddExperienceBox';
 import TeamManagerWrapper from './TeamManagerWrapper';
 import TeamSummaryBox from './TeamSummaryBox';
+import TeamSummaryMembers from './TeamSummaryMembers';
+import TeamSummaryRoles from './TeamSummaryRoles';
+import TeamSummaryTable from './TeamSummaryTable';
+import TeamSummaryWrapper from './TeamSummaryWrapper';
 
 
 export {
@@ -37,4 +41,8 @@ export {
   AddExperienceBox,
   TeamManagerWrapper,
   TeamSummaryBox,
+  TeamSummaryMembers,
+  TeamSummaryRoles,
+  TeamSummaryTable,
+  TeamSummaryWrapper,
 }

--- a/client/src/containers/TeamDetails.js
+++ b/client/src/containers/TeamDetails.js
@@ -8,6 +8,8 @@ import * as actionCreators from '../redux/actions/actionCreators';
 
 import {
   TeamSummaryBox,
+  TeamSummaryTable,
+  TeamSummaryWrapper,
 } from './../components/componentIndex';
 
 class TeamDetails extends Component {
@@ -26,13 +28,11 @@ class TeamDetails extends Component {
 
   render() {
     return (
-      <div>
-        <TeamSummaryBox
-          team={this.props.teams.team}
-          location={this.props.teams.location}
-          project={this.props.teams.project}
-        />
-      </div>
+      <TeamSummaryWrapper
+        team={this.props.teams.team}
+        location={this.props.teams.location}
+        project={this.props.teams.project}
+      />
     )
   }
 }

--- a/client/src/containers/TeamManager.js
+++ b/client/src/containers/TeamManager.js
@@ -67,7 +67,7 @@ class TeamManager extends Component {
           <TableBody>
             {this.props.teams.allTeams.map(team => {
               return (
-                <TableRow key={team.id} onClick={()=>{this.handleRowClick(team.identity)}} >
+                <TableRow key={team.identity} onClick={()=>{this.handleRowClick(team.identity)}} >
                   <TableCell>{team.properties.name}</TableCell>
                   <TableCell>{team.properties.projectName}</TableCell>
                   <TableCell>{team.properties.startDate}</TableCell>

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -5,8 +5,8 @@ import './styles/index.css';
 import Root from './Root';
 import registerServiceWorker from './registerServiceWorker';
 
-console.log(process.env.neo4jConnectionString)
-console.log(process.env.DOMAIN)
+// console.log(process.env.neo4jConnectionString)
+// console.log(process.env.DOMAIN)
 
 ReactDOM.render(<Root />, document.getElementById('root'));
 registerServiceWorker();

--- a/client/src/redux/modules/team.js
+++ b/client/src/redux/modules/team.js
@@ -9,16 +9,19 @@ import {
   GET_TEAM_FULFILLED,
 } from '../../utils/types';
 
+import { getAllTeams } from '../../core/services/teams';
+
 const DOMAIN = window.location.host || 'localhost'
+
 
 const addTeamEpic = (action$, state) => {
   return action$
     .ofType(ADD_TEAM)
     .mergeMap(
       action => {
-        return ajax.post(`http://${DOMAIN}:4000/api/team`, action.payload)
+        return getAllTeams()
           .map(({response}) => {
-            return getTeamFulfilled(response)
+            return getTeamFulfilled(response.data)
           })
       }
     )

--- a/client/src/redux/modules/team.js
+++ b/client/src/redux/modules/team.js
@@ -9,19 +9,16 @@ import {
   GET_TEAM_FULFILLED,
 } from '../../utils/types';
 
-import { getAllTeams } from '../../core/services/teams';
-
 const DOMAIN = window.location.host || 'localhost'
-
 
 const addTeamEpic = (action$, state) => {
   return action$
     .ofType(ADD_TEAM)
     .mergeMap(
       action => {
-        return getAllTeams()
+        return ajax.post(`http://${DOMAIN}:4000/api/team`, action.payload)
           .map(({response}) => {
-            return getTeamFulfilled(response.data)
+            return getTeamFulfilled(response)
           })
       }
     )

--- a/server/database/databaseUtilities.js
+++ b/server/database/databaseUtilities.js
@@ -4,7 +4,6 @@ const neo4j = require('neo4j-driver').v1;
 function extractNodes(queryResult) {
 
   return _.reduce(queryResult, (acc, value) => {
-    console.log(acc, value)
     const fields = value._fields;
     const nodes =  _.map(fields, ({ properties, labels, identity }) => {
       return {
@@ -71,5 +70,3 @@ module.exports = {
   mapTypeToQuery,
   createSetChain,
 }
-
-

--- a/server/routers/contractorExperienceRouter.js
+++ b/server/routers/contractorExperienceRouter.js
@@ -18,6 +18,13 @@ router.post('/', (req, res) => {
     .then(result => res.send(result))
 })
 
+router.post('/position', (req, res) => {
+  const { body, query, graphApi } = req;
+
+  graphApi.connectContractorToPositionViaExperience(body)
+    .then(result => res.send(result))
+})
+
 router.delete('/', (req, res) => {
 
   const { identity } =  req.query


### PR DESCRIPTION
This PR just makes some improvements to the TeamSummary section within the Team Manager. It breaks down the existing presentational component into a few separate ones for easier handling.
I also create a new API method, connectContractorToPositionViaExperience, which creates an Experience node and then connects that node to a Contractor node and a PositionLevel node (this is how we will add team members - I think).